### PR TITLE
add an option to handle array of values in a query parameter

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -28,22 +28,23 @@ You can override the HTTP query parameters by:
 * Adding to or updating the list of query parameters
 * Removing query parameters individually
 
+You can also append a value to an existing query parameter.
+
 The query parameter values of the incoming request are accessible via the `{#request.params['query_parameter_name']}` construct.
 
 == Compatibility with APIM
 
 |===
-| Plugin version | APIM version
-| 1.x            | All supported versions
+|Plugin version | APIM version
+
+|Up to 1.6.x    | 3.x
+|1.7.x          | 4.0 to latest
 |===
 
 
-== Example
-
-The example below shows how to add the ID of the incoming request to the outgoing request.
-
-[source, json]
-.Sample
+== Examples
+=== Add the ID of the incoming request to the outgoing request
+[source,json]
 ----
 "transform-queryparams": {
     "addQueryParameters": [
@@ -51,9 +52,93 @@ The example below shows how to add the ID of the incoming request to the outgoin
             "name": "myParam",
             "value": "{#request.id}"
         }
-    ],
-    "removeQueryParameters": [
-        "secretParam"
     ]
 }
 ----
+`https://host:port/path?foo=bar` becomes `https://host:port/path?a=b&myParam=my-request-id`
+
+=== Remove existing param and add a new one
+[source, json]
+----
+"transform-queryparams": {
+    "removeQueryParameters": [
+        "foo"
+    ],
+    "addQueryParameters": [
+        {
+            "name": "myParam",
+            "value": "myValue"
+        }
+    ]
+}
+----
+`https://host:port/path?foo=bar&key=value` becomes `https://host:port/path?key=value&myParam=myValue`
+
+=== Remove all existing params and add a new one
+[source, json]
+----
+"transform-queryparams": {
+    "clearAll": true,
+    "addQueryParameters": [
+        {
+            "name": "myParam",
+            "value": "myValue"
+        }
+    ]
+}
+----
+`https://host:port/path?foo=bar&key=value` becomes `https://host:port/path?myParam=myValue`
+
+=== Replace an existing param
+[source, json]
+----
+"transform-queryparams": {
+    "addQueryParameters": [
+        {
+            "name": "myParam",
+            "value": "myNewValue"
+        }
+    ]
+}
+----
+`https://host:port/path?myParam=myValue` becomes `https://host:port/path?myParam=myNewValue`
+
+=== Append multiple values to an existing param
+[source, json]
+----
+"transform-queryparams": {
+    "addQueryParameters": [
+        {
+            "name": "foo",
+            "value": "bar2",
+            "appendToExistingArray": true
+        },
+        {
+            "name": "foo",
+            "value": "bar3",
+            "appendToExistingArray": true
+        }
+    ]
+}
+----
+`https://host:port/path?foo=bar` becomes `https://host:port/path?foo=bar&foo=bar2&foo=bar3`
+
+=== Replace an existing param with an array
+[source, json]
+----
+"transform-queryparams": {
+    "addQueryParameters": [
+        {
+            "name": "foo",
+            "value": "bar2",
+            "appendToExistingArray": false
+        },
+        {
+            "name": "foo",
+            "value": "bar3",
+            "appendToExistingArray": true
+        }
+    ]
+}
+----
+`https://host:port/path?foo=bar` becomes `https://host:port/path?foo=bar2&foo=bar3`

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,12 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Test scope -->
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -96,14 +96,19 @@
 
         <!-- Test scope -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/gravitee/policy/transformqueryparams/TransformQueryParametersPolicy.java
+++ b/src/main/java/io/gravitee/policy/transformqueryparams/TransformQueryParametersPolicy.java
@@ -21,6 +21,7 @@ import io.gravitee.gateway.api.Response;
 import io.gravitee.policy.api.PolicyChain;
 import io.gravitee.policy.api.annotations.OnRequest;
 import io.gravitee.policy.transformqueryparams.configuration.TransformQueryParametersPolicyConfiguration;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -71,7 +72,16 @@ public class TransformQueryParametersPolicy {
                             if (extValue.contains(WHITESPACE)) {
                                 extValue = extValue.replaceAll(WHITESPACE, ENCODED_WHITESPACE);
                             }
-                            List<String> values = new LinkedList<>();
+
+                            List<String> values;
+                            if (queryParameter.isAppendToExistingArray()) {
+                                values = request.parameters().get(name);
+                                if (values == null) {
+                                    values = new LinkedList<>();
+                                }
+                            } else {
+                                values = new LinkedList<>();
+                            }
                             values.add(extValue);
                             request.parameters().put(name, values);
                         } catch (Exception ex) {

--- a/src/main/java/io/gravitee/policy/transformqueryparams/configuration/HttpQueryParameter.java
+++ b/src/main/java/io/gravitee/policy/transformqueryparams/configuration/HttpQueryParameter.java
@@ -36,6 +36,8 @@ public class HttpQueryParameter {
 
     private String value;
 
+    private boolean appendToExistingArray;
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/io/gravitee/policy/transformqueryparams/configuration/HttpQueryParameter.java
+++ b/src/main/java/io/gravitee/policy/transformqueryparams/configuration/HttpQueryParameter.java
@@ -16,31 +16,25 @@
 package io.gravitee.policy.transformqueryparams.configuration;
 
 import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * @author David BRASSELY (brasseld at gmail.com)
  */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class HttpQueryParameter {
 
     private String name;
 
     private String value;
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getValue() {
-        return value;
-    }
-
-    public void setValue(String value) {
-        this.value = value;
-    }
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,45 +1,42 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "additionalProperties": false,
-  "properties" : {
-    "clearAll" : {
-      "type" : "boolean",
-      "title": "Clear all query parameters",
-      "description": "Please be aware that by clearing all query parameters, you mustn't be able to use them in expression language."
-    },
-    "removeQueryParameters" : {
-      "type" : "array",
-      "title": "Remove query parameters",
-      "items" : {
-        "type" : "string",
-        "title": "Query Parameter"
-      }
-    },
-    "addQueryParameters" : {
-      "type" : "array",
-      "title": "Add query parameter",
-      "items" : {
-        "type" : "object",
-        "title": "Query Parameter",
-        "properties" : {
-          "name" : {
-            "title": "Name",
-            "type" : "string"
-          },
-          "value" : {
-            "title": "Value. (Supports EL)",
-            "type" : "string",
-            "x-schema-form": {
-              "expression-language": true
-            }
-          }
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "clearAll": {
+            "type": "boolean",
+            "title": "Clear all query parameters",
+            "description": "Please be aware that by clearing all query parameters, you mustn't be able to use them in expression language."
         },
-        "required": [
-          "name",
-          "value"
-        ]
-      }
+        "removeQueryParameters": {
+            "type": "array",
+            "title": "Remove query parameters",
+            "items": {
+                "type": "string",
+                "title": "Query Parameter"
+            }
+        },
+        "addQueryParameters": {
+            "type": "array",
+            "title": "Add query parameter",
+            "items": {
+                "type": "object",
+                "title": "Query Parameter",
+                "properties": {
+                    "name": {
+                        "title": "Name",
+                        "type": "string"
+                    },
+                    "value": {
+                        "title": "Value. (Supports EL)",
+                        "type": "string",
+                        "x-schema-form": {
+                            "expression-language": true
+                        }
+                    }
+                },
+                "required": ["name", "value"]
+            }
+        }
     }
-  }
 }

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -18,7 +18,7 @@
         },
         "addQueryParameters": {
             "type": "array",
-            "title": "Add query parameter",
+            "title": "Add or replace query parameter",
             "items": {
                 "type": "object",
                 "title": "Query Parameter",
@@ -33,6 +33,11 @@
                         "x-schema-form": {
                             "expression-language": true
                         }
+                    },
+                    "appendToExistingArray": {
+                        "title": "Append the value to existing queryParam as an array (i.e. ?key=v1&key=v2&key=v3) ?",
+                        "type": "boolean",
+                        "default": false
                     }
                 },
                 "required": ["name", "value"]

--- a/src/test/java/io/gravitee/policy/transformqueryparams/TransformQueryParametersPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/transformqueryparams/TransformQueryParametersPolicyTest.java
@@ -31,6 +31,7 @@ import io.gravitee.policy.api.PolicyChain;
 import io.gravitee.policy.transformqueryparams.configuration.HttpQueryParameter;
 import io.gravitee.policy.transformqueryparams.configuration.TransformQueryParametersPolicyConfiguration;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -190,6 +191,49 @@ public class TransformQueryParametersPolicyTest {
                 List.of(),
                 new LinkedMultiValueMap<>(),
                 new LinkedMultiValueMap<>(Map.of("foo", List.of("bar2"))),
+                false
+            ),
+            Arguments.of(
+                "append param to an array",
+                List.of(
+                    HttpQueryParameter.builder().name("foo").value("bar").build(),
+                    HttpQueryParameter.builder().name("foo").value("bar2").appendToExistingArray(true).build()
+                ),
+                List.of(),
+                new LinkedMultiValueMap<>(),
+                new LinkedMultiValueMap<>(Map.of("foo", List.of("bar", "bar2"))),
+                false
+            ),
+            Arguments.of(
+                "append param to an existing array",
+                List.of(HttpQueryParameter.builder().name("foo").value("bar2").appendToExistingArray(true).build()),
+                List.of(),
+                new LinkedMultiValueMap<>(Map.of("foo", new ArrayList<>(List.of("bar")))),
+                new LinkedMultiValueMap<>(Map.of("foo", List.of("bar", "bar2"))),
+                false
+            ),
+            Arguments.of(
+                "append multiple values into an array",
+                List.of(
+                    HttpQueryParameter.builder().name("foo").value("bar").appendToExistingArray(true).build(),
+                    HttpQueryParameter.builder().name("foo").value("bar2").appendToExistingArray(true).build(),
+                    HttpQueryParameter.builder().name("foo").value("bar3").appendToExistingArray(true).build()
+                ),
+                List.of(),
+                new LinkedMultiValueMap<>(),
+                new LinkedMultiValueMap<>(Map.of("foo", List.of("bar", "bar2", "bar3"))),
+                false
+            ),
+            Arguments.of(
+                "replace an existing param with an array",
+                List.of(
+                    HttpQueryParameter.builder().name("foo").value("bar").appendToExistingArray(false).build(),
+                    HttpQueryParameter.builder().name("foo").value("bar2").appendToExistingArray(true).build(),
+                    HttpQueryParameter.builder().name("foo").value("bar3").appendToExistingArray(true).build()
+                ),
+                List.of(),
+                new LinkedMultiValueMap<>(Map.of("foo", List.of("oldvalue"))),
+                new LinkedMultiValueMap<>(Map.of("foo", List.of("bar", "bar2", "bar3"))),
                 false
             )
         );

--- a/src/test/java/io/gravitee/policy/transformqueryparams/TransformQueryParametersPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/transformqueryparams/TransformQueryParametersPolicyTest.java
@@ -76,221 +76,239 @@ public class TransformQueryParametersPolicyTest {
 
     @Test
     public void shouldAddSimpleParam() {
-        List<HttpQueryParameter> parameters = new ArrayList<>();
-        HttpQueryParameter param = new HttpQueryParameter();
-        param.setName("foo");
-        param.setValue("bar");
-        parameters.add(param);
-        when(configuration.isClearAll()).thenReturn(false);
-        when(configuration.getAddQueryParameters()).thenReturn(parameters);
-        MultiValueMap requestParams = new LinkedMultiValueMap();
-        when(request.parameters()).thenReturn(requestParams);
+        List<HttpQueryParameter> addQueryParameters = new ArrayList<>() {
+            {
+                add(HttpQueryParameter.builder().name("foo").value("bar").build());
+            }
+        };
+        List<String> removeQueryParameters = new ArrayList<>();
+        MultiValueMap<String, String> requestQueryParams = new LinkedMultiValueMap<>();
+        MultiValueMap<String, String> expectedQueryParams = new LinkedMultiValueMap<>() {
+            {
+                add("foo", "bar");
+            }
+        };
 
-        policy.onRequest(request, response, executionContext, policyChain);
-
-        assertNotNull(request.parameters().get("foo"));
-        assertEquals(1, request.parameters().get("foo").size());
-        assertEquals("bar", request.parameters().get("foo").get(0));
+        shouldTest(requestQueryParams, addQueryParameters, removeQueryParameters, expectedQueryParams, false);
     }
 
     @Test
     public void shouldAddSimpleParamAndKeepExistingParams() {
-        List<HttpQueryParameter> parameters = new ArrayList<>();
-        HttpQueryParameter param = new HttpQueryParameter();
-        param.setName("foo");
-        param.setValue("bar");
-        parameters.add(param);
-        when(configuration.isClearAll()).thenReturn(false);
-        when(configuration.getAddQueryParameters()).thenReturn(parameters);
-        MultiValueMap requestParams = new LinkedMultiValueMap();
-        requestParams.add("existing", "value");
-        when(request.parameters()).thenReturn(requestParams);
+        List<HttpQueryParameter> addQueryParameters = new ArrayList<>() {
+            {
+                add(HttpQueryParameter.builder().name("foo").value("bar").build());
+            }
+        };
+        List<String> removeQueryParameters = new ArrayList<>();
+        MultiValueMap<String, String> requestQueryParams = new LinkedMultiValueMap<>() {
+            {
+                add("existing", "value");
+            }
+        };
+        MultiValueMap<String, String> expectedQueryParams = new LinkedMultiValueMap<>() {
+            {
+                add("existing", "value");
+                add("foo", "bar");
+            }
+        };
 
-        policy.onRequest(request, response, executionContext, policyChain);
-
-        assertNotNull(request.parameters().get("foo"));
-        assertEquals(1, request.parameters().get("foo").size());
-        assertEquals("bar", request.parameters().get("foo").get(0));
-        assertNotNull(request.parameters().get("existing"));
-        assertEquals(1, request.parameters().get("existing").size());
-        assertEquals("value", request.parameters().get("existing").get(0));
+        shouldTest(requestQueryParams, addQueryParameters, removeQueryParameters, expectedQueryParams, false);
     }
 
     @Test
     public void shouldAddEncodedParam() {
-        List<HttpQueryParameter> parameters = new ArrayList<>();
-        HttpQueryParameter param = new HttpQueryParameter();
-        param.setName("foo%20name");
-        param.setValue("bar%20name");
-        parameters.add(param);
-        when(configuration.isClearAll()).thenReturn(false);
-        when(configuration.getAddQueryParameters()).thenReturn(parameters);
-        MultiValueMap requestParams = new LinkedMultiValueMap();
-        when(request.parameters()).thenReturn(requestParams);
+        List<HttpQueryParameter> addQueryParameters = new ArrayList<>() {
+            {
+                add(HttpQueryParameter.builder().name("foo%20name").value("bar%20name").build());
+            }
+        };
+        List<String> removeQueryParameters = new ArrayList<>();
+        MultiValueMap<String, String> requestQueryParams = new LinkedMultiValueMap<>();
+        MultiValueMap<String, String> expectedQueryParams = new LinkedMultiValueMap<>() {
+            {
+                add("foo%20name", "bar%20name");
+            }
+        };
 
-        policy.onRequest(request, response, executionContext, policyChain);
-
-        assertNotNull(request.parameters().get("foo%20name"));
-        assertEquals(1, request.parameters().get("foo%20name").size());
-        assertEquals("bar%20name", request.parameters().get("foo%20name").get(0));
+        shouldTest(requestQueryParams, addQueryParameters, removeQueryParameters, expectedQueryParams, false);
     }
 
     @Test
     public void shouldAddUnencodedParam() {
-        List<HttpQueryParameter> parameters = new ArrayList<>();
-        HttpQueryParameter param = new HttpQueryParameter();
-        param.setName("foo&name");
-        param.setValue("bar'name&=3");
-        parameters.add(param);
-        when(configuration.isClearAll()).thenReturn(false);
-        when(configuration.getAddQueryParameters()).thenReturn(parameters);
-        MultiValueMap requestParams = new LinkedMultiValueMap();
-        when(request.parameters()).thenReturn(requestParams);
+        List<HttpQueryParameter> addQueryParameters = new ArrayList<>() {
+            {
+                add(HttpQueryParameter.builder().name("foo&name").value("bar'name&=3").build());
+            }
+        };
+        List<String> removeQueryParameters = new ArrayList<>();
+        MultiValueMap<String, String> requestQueryParams = new LinkedMultiValueMap<>();
+        MultiValueMap<String, String> expectedQueryParams = new LinkedMultiValueMap<>() {
+            {
+                add("foo&name", "bar'name&=3");
+            }
+        };
 
-        policy.onRequest(request, response, executionContext, policyChain);
-
-        assertNotNull(request.parameters().get("foo&name"));
-        assertEquals(1, request.parameters().get("foo&name").size());
-        assertEquals("bar'name&=3", request.parameters().get("foo&name").get(0));
+        shouldTest(requestQueryParams, addQueryParameters, removeQueryParameters, expectedQueryParams, false);
     }
 
     @Test
     public void shouldEncodeWhitespaceParam() {
-        List<HttpQueryParameter> parameters = new ArrayList<>();
-        HttpQueryParameter param = new HttpQueryParameter();
-        param.setName("foo name");
-        param.setValue("bar name");
-        parameters.add(param);
-        when(configuration.isClearAll()).thenReturn(false);
-        when(configuration.getAddQueryParameters()).thenReturn(parameters);
-        MultiValueMap requestParams = new LinkedMultiValueMap();
-        when(request.parameters()).thenReturn(requestParams);
+        List<HttpQueryParameter> addQueryParameters = new ArrayList<>() {
+            {
+                add(HttpQueryParameter.builder().name("foo name").value("bar name").build());
+            }
+        };
+        List<String> removeQueryParameters = new ArrayList<>();
+        MultiValueMap<String, String> requestQueryParams = new LinkedMultiValueMap<>();
+        MultiValueMap<String, String> expectedQueryParams = new LinkedMultiValueMap<>() {
+            {
+                add("foo%20name", "bar%20name");
+            }
+        };
 
-        policy.onRequest(request, response, executionContext, policyChain);
-
-        assertNotNull(request.parameters().get("foo%20name"));
-        assertEquals(1, request.parameters().get("foo%20name").size());
-        assertEquals("bar%20name", request.parameters().get("foo%20name").get(0));
+        shouldTest(requestQueryParams, addQueryParameters, removeQueryParameters, expectedQueryParams, false);
     }
 
     @Test
     public void shouldClearAll() {
-        when(configuration.isClearAll()).thenReturn(true);
-        MultiValueMap requestParams = new LinkedMultiValueMap();
-        requestParams.add("foo", "bar");
-        when(request.parameters()).thenReturn(requestParams);
+        List<HttpQueryParameter> addQueryParameters = new ArrayList<>();
+        List<String> removeQueryParameters = new ArrayList<>();
+        MultiValueMap<String, String> requestQueryParams = new LinkedMultiValueMap<>() {
+            {
+                add("foo% 20name", "bar%20name");
+            }
+        };
+        MultiValueMap<String, String> expectedQueryParams = new LinkedMultiValueMap<>();
 
-        assertFalse(request.parameters().isEmpty());
-
-        policy.onRequest(request, response, executionContext, policyChain);
-
-        assertTrue(request.parameters().isEmpty());
+        shouldTest(requestQueryParams, addQueryParameters, removeQueryParameters, expectedQueryParams, true);
     }
 
     @Test
     public void shouldOverride() {
-        when(configuration.isClearAll()).thenReturn(false);
-        List<HttpQueryParameter> parameters = new ArrayList<>();
-        HttpQueryParameter param = new HttpQueryParameter();
-        param.setName("foo");
-        param.setValue("newbar");
-        parameters.add(param);
-        when(configuration.getAddQueryParameters()).thenReturn(parameters);
-        when(configuration.isClearAll()).thenReturn(false);
-        MultiValueMap requestParams = new LinkedMultiValueMap();
-        requestParams.add("foo", "bar");
-        when(request.parameters()).thenReturn(requestParams);
+        List<HttpQueryParameter> addQueryParameters = new ArrayList<>() {
+            {
+                add(HttpQueryParameter.builder().name("foo").value("newbar").build());
+            }
+        };
+        List<String> removeQueryParameters = new ArrayList<>();
+        MultiValueMap<String, String> requestQueryParams = new LinkedMultiValueMap<>() {
+            {
+                add("foo", "bar");
+            }
+        };
+        MultiValueMap<String, String> expectedQueryParams = new LinkedMultiValueMap<>() {
+            {
+                add("foo", "newbar");
+            }
+        };
 
-        policy.onRequest(request, response, executionContext, policyChain);
-
-        assertNotNull(request.parameters().get("foo"));
-        assertEquals(1, request.parameters().get("foo").size());
-        assertEquals("newbar", request.parameters().get("foo").get(0));
+        shouldTest(requestQueryParams, addQueryParameters, removeQueryParameters, expectedQueryParams, false);
     }
 
     @Test
     public void shouldRemoveAllAndAdd() {
-        when(configuration.isClearAll()).thenReturn(true);
-        List<HttpQueryParameter> parameters = new ArrayList<>();
-        HttpQueryParameter param = new HttpQueryParameter();
-        param.setName("foo");
-        param.setValue("bar");
-        parameters.add(param);
-        when(configuration.getAddQueryParameters()).thenReturn(parameters);
-        MultiValueMap requestParams = new LinkedMultiValueMap();
-        requestParams.add("old", "value");
-        when(request.parameters()).thenReturn(requestParams);
+        List<HttpQueryParameter> addQueryParameters = new ArrayList<>() {
+            {
+                add(HttpQueryParameter.builder().name("foo").value("bar").build());
+            }
+        };
+        List<String> removeQueryParameters = new ArrayList<>();
+        MultiValueMap<String, String> requestQueryParams = new LinkedMultiValueMap<>() {
+            {
+                add("old", "value");
+            }
+        };
+        MultiValueMap<String, String> expectedQueryParams = new LinkedMultiValueMap<>() {
+            {
+                add("foo", "bar");
+            }
+        };
 
-        policy.onRequest(request, response, executionContext, policyChain);
-
-        assertNotNull(request.parameters().get("foo"));
-        assertEquals(1, request.parameters().get("foo").size());
-        assertEquals("bar", request.parameters().get("foo").get(0));
-        assertNull(request.parameters().get("old"));
+        shouldTest(requestQueryParams, addQueryParameters, removeQueryParameters, expectedQueryParams, true);
     }
 
     @Test
     public void shouldRemoveParam() {
-        when(configuration.isClearAll()).thenReturn(false);
-        List<String> parameters = new ArrayList<>();
-        String param = "foo";
-        parameters.add(param);
-        when(configuration.getRemoveQueryParameters()).thenReturn(parameters);
-        MultiValueMap requestParams = new LinkedMultiValueMap();
-        requestParams.add("existing", "value");
-        when(request.parameters()).thenReturn(requestParams);
+        List<HttpQueryParameter> addQueryParameters = new ArrayList<>();
+        List<String> removeQueryParameters = new ArrayList<>() {
+            {
+                add("foo");
+            }
+        };
+        MultiValueMap<String, String> requestQueryParams = new LinkedMultiValueMap<>() {
+            {
+                add("foo", "bar");
+                add("old", "value");
+            }
+        };
+        MultiValueMap<String, String> expectedQueryParams = new LinkedMultiValueMap<>() {
+            {
+                add("old", "value");
+            }
+        };
 
-        policy.onRequest(request, response, executionContext, policyChain);
-
-        assertNotNull(request.parameters().get("existing"));
-        assertNull(request.parameters().get("foo"));
+        shouldTest(requestQueryParams, addQueryParameters, removeQueryParameters, expectedQueryParams, false);
     }
 
     @Test
-    public void shouldVerifyOrderAddAndRemoveParam() {
-        when(configuration.isClearAll()).thenReturn(false);
-        List<HttpQueryParameter> parameters = new ArrayList<>();
-        HttpQueryParameter param = new HttpQueryParameter();
-        param.setName("foo");
-        param.setValue("bar");
-        parameters.add(param);
-        when(configuration.isClearAll()).thenReturn(false);
-        when(configuration.getAddQueryParameters()).thenReturn(parameters);
+    public void shouldVerifyOrderAddThenRemoveParam() {
+        List<HttpQueryParameter> addQueryParameters = new ArrayList<>() {
+            {
+                add(HttpQueryParameter.builder().name("foo").value("bar").build());
+            }
+        };
+        List<String> removeQueryParameters = new ArrayList<>() {
+            {
+                add("foo");
+            }
+        };
+        MultiValueMap<String, String> requestQueryParams = new LinkedMultiValueMap<>() {
+            {
+                add("existing", "value");
+            }
+        };
+        MultiValueMap<String, String> expectedQueryParams = new LinkedMultiValueMap<>() {
+            {
+                add("existing", "value");
+            }
+        };
 
-        List<String> removeparameters = new ArrayList<>();
-        String removeparam = "foo";
-        removeparameters.add(removeparam);
-        when(configuration.getRemoveQueryParameters()).thenReturn(removeparameters);
-        MultiValueMap requestParams = new LinkedMultiValueMap();
-        requestParams.add("existing", "value");
-        when(request.parameters()).thenReturn(requestParams);
-
-        policy.onRequest(request, response, executionContext, policyChain);
-
-        assertNotNull(request.parameters().get("existing"));
-        assertNull(request.parameters().get("foo"));
+        shouldTest(requestQueryParams, addQueryParameters, removeQueryParameters, expectedQueryParams, false);
     }
 
     @Test
     public void shouldAddParamDoubleTime() {
-        List<HttpQueryParameter> parameters = new ArrayList<>();
-        HttpQueryParameter param1 = new HttpQueryParameter();
-        param1.setName("foo");
-        param1.setValue("bar1");
-        parameters.add(param1);
-        HttpQueryParameter param2 = new HttpQueryParameter();
-        param2.setName("foo");
-        param2.setValue("bar2");
-        parameters.add(param2);
-        when(configuration.isClearAll()).thenReturn(false);
-        when(configuration.getAddQueryParameters()).thenReturn(parameters);
-        MultiValueMap requestParams = new LinkedMultiValueMap();
-        when(request.parameters()).thenReturn(requestParams);
+        List<HttpQueryParameter> addQueryParameters = new ArrayList<>() {
+            {
+                add(HttpQueryParameter.builder().name("foo").value("bar").build());
+                add(HttpQueryParameter.builder().name("foo").value("bar2").build());
+            }
+        };
+        List<String> removeQueryParameters = new ArrayList<>();
+        MultiValueMap<String, String> requestQueryParams = new LinkedMultiValueMap<>();
+        MultiValueMap<String, String> expectedQueryParams = new LinkedMultiValueMap<>() {
+            {
+                add("foo", "bar2");
+            }
+        };
+
+        shouldTest(requestQueryParams, addQueryParameters, removeQueryParameters, expectedQueryParams, false);
+    }
+
+    private void shouldTest(
+        MultiValueMap<String, String> requestQueryParams,
+        List<HttpQueryParameter> addQueryParameters,
+        List<String> removeQueryParameters,
+        MultiValueMap<String, String> expectedQueryParams,
+        boolean clearAll
+    ) {
+        when(configuration.isClearAll()).thenReturn(clearAll);
+        when(configuration.getAddQueryParameters()).thenReturn(addQueryParameters);
+        when(configuration.getRemoveQueryParameters()).thenReturn(removeQueryParameters);
+        when(request.parameters()).thenReturn(requestQueryParams);
 
         policy.onRequest(request, response, executionContext, policyChain);
 
-        assertNotNull(request.parameters().get("foo"));
-        assertEquals(1, request.parameters().get("foo").size());
-        assertEquals("bar2", request.parameters().get("foo").get(0));
+        assertEquals(expectedQueryParams, request.parameters());
     }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3315

**Description**

This 4 first commits of this PR are here to format files and refactor a little bit the unit tests.

The last commit add an option to handle query param as arrays.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.8.0-apim-3315-handle-multi-valued-query-param-master-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-transformqueryparams/1.8.0-apim-3315-handle-multi-valued-query-param-master-SNAPSHOT/gravitee-policy-transformqueryparams-1.8.0-apim-3315-handle-multi-valued-query-param-master-SNAPSHOT.zip)
  <!-- Version placeholder end -->
