### PR TITLE
feat: enable the policy for LLM_PROXY APIs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.12.1
-
+    gravitee: gravitee-io/gravitee@5.8.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/.claude/skills/gravitee-policy-docgen-migration/SKILL.md
+++ b/.claude/skills/gravitee-policy-docgen-migration/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: gravitee-policy-docgen-migration
+description: Migrate a Gravitee APIM policy repository from README.adoc-based documentation to gravitee-doc-gen sources and outputs. Use when a repo has README.adoc policy docs and needs .docgen files (overview.md, matrix.yaml, examples.yaml, .docgen/examples/*), generated docs, and src/assembly/policy-assembly.xml updated to package docs/.
+---
+
+# Gravitee Policy Doc-Gen Migration
+
+## Overview
+
+Migrate documentation for a Gravitee policy plugin from legacy `README.adoc` sources to the doc-gen workflow with deterministic validation.
+
+Keep runtime policy behavior unchanged. Limit changes to documentation sources, generated docs, and packaging inputs.
+
+## Inputs
+
+Require these repository files before starting:
+
+- `README.adoc`
+- `src/assembly/policy-assembly.xml`
+- `src/main/resources/schemas/schema-form.json`
+
+Prefer existing V4 API fixtures as examples source:
+
+- `src/test/resources/apis/v4/*.json`
+
+If no V4 fixtures exist, fallback in this order:
+
+- `src/test/resources/apis/*.json`
+- `src/test/resources/apis/v2/*.json`
+
+## Migration Workflow
+
+1. Inspect current docs and examples.
+- Read `README.adoc` sections: description, compatibility, configuration, identifier, notices.
+- Read fixture JSON files and extract only policy `configuration` objects.
+- Keep examples grounded in existing fixtures; do not invent structures unless no fixture exists.
+
+2. Create doc-gen source files.
+- Create `.docgen/overview.md` from README narrative sections. Remove or don't include phase information in overview.md - docgen extracts this from policy.properties automatically. The phase property in examples.yaml is only for scoping that specific example, not declaring policy phases.
+- Create `.docgen/matrix.yaml` from compatibility history.
+- Create `.docgen/examples.yaml` with `genExamples: []` and `rawExamples` entries.
+- Create `.docgen/examples/*.json` files with policy configuration payloads.
+- Create a `.docgen/errors.yaml` file with error codes and descriptions. You can check the source code to find ExecutionFailure keys
+
+3. Preflight schema compatibility for doc-gen.
+- Ensure JSON Schema keywords have valid types in `src/main/resources/schemas/schema-form.json`.
+- Specifically, `deprecated` must be a boolean (`true`/`false`), not a string (`"true"`/`"false"`).
+- Apply only typing fixes required for schema validity; do not alter runtime semantics.
+
+4. Update packaging input.
+- Edit `src/assembly/policy-assembly.xml`.
+- Replace README fileSet include from `README.adoc` to a docs include that preserves directory structure:
+```xml
+<fileSet>
+    <directory>${basedir}</directory>
+    <includes>
+        <include>docs/**</include>
+    </includes>
+    <outputDirectory>./</outputDirectory>
+</fileSet>
+```
+- Avoid `<directory>docs</directory>` with `./` output because it can flatten files in the ZIP.
+
+5. Generate docs.
+- Prompt user for a doc-gen config directory path (absolute path to folder containing files like `bootstrap.yaml` and `policy/default.yaml`).
+- Run:
+```bash
+DOCGEN_CONFIG_DIR="<value provided by the user>"
+docker run --rm -v "$DOCGEN_CONFIG_DIR":/config -v ./:/plugin graviteeio/doc-gen
+```
+- Optional compatibility alias:
+```bash
+export DOCGEN_ROOT="$DOCGEN_CONFIG_DIR"
+```
+
+6. Validate.
+- Validate YAML files parse.
+- Validate JSON examples parse.
+- Run `mvn -DskipTests package`.
+- Confirm generated ZIP contains `docs/` and `docs/POLICY_STUDIO_DOC.md`.
+
+## File Conventions
+
+Use this minimum file set:
+
+- `.docgen/overview.md`
+- `.docgen/errors.yaml`
+- `.docgen/matrix.yaml`
+- `.docgen/examples.yaml`
+- `.docgen/examples/<example>.json`
+- `README.md` (generated)
+- `docs/POLICY_STUDIO_DOC.md` (generated)
+
+Keep `README.adoc` in the repository unless explicitly requested to remove it.
+
+## Examples YAML Pattern
+
+Use this shape:
+
+```yaml
+genExamples: []
+rawExamples:
+  - title: <example title>
+    templateRef: v4-api-proxy
+    language: json
+    properties:
+      phase: request
+    file: .docgen/examples/<file>.json
+```
+
+Use `phase: response` for response-scope examples.
+
+## Validation Commands
+
+```bash
+ruby -e 'require "yaml"; YAML.load_file(".docgen/examples.yaml"); YAML.load_file(".docgen/matrix.yaml"); YAML.load_file(".docgen/errors.yaml")'
+for f in .docgen/examples/*.json; do jq empty "$f"; done
+mvn -DskipTests package
+unzip -l target/*.zip | rg "docs/|POLICY_STUDIO_DOC"
+```
+
+## Troubleshooting
+
+### YAML Validation Failures
+
+**Symptom**: `ruby -e 'require "yaml"; YAML.load_file(...)'` fails with parse error.
+
+**Fix**:
+- Check indentation (use spaces, not tabs).
+- Validate quotes around strings with special characters.
+- Ensure list items use `- ` prefix consistently.
+- Use online YAML validator for complex structures.
+
+### JSON Validation Failures
+
+**Symptom**: `jq empty` exits non-zero.
+
+**Fix**:
+- Run `jq . .docgen/examples/<file>.json` to see parse error location.
+- Check for trailing commas (invalid in JSON).
+- Ensure all strings are double-quoted.
+- Validate brackets/braces are balanced.
+
+### Docker Not Available
+
+**Symptom**: `docker: command not found` or permission denied.
+
+**Fix**:
+- Ask user to install Docker
+
+### Doc-Gen Image Pull Failures
+
+**Symptom**: Cannot pull `graviteeio/doc-gen` image.
+
+**Fix**:
+- Check network connectivity.
+- Try explicit pull: `docker pull graviteeio/doc-gen:latest`.
+
+### Generated Docs Missing from ZIP
+
+**Symptom**: `unzip -l target/*.zip | rg docs/` shows no results.
+
+**Fix**:
+- Verify `policy-assembly.xml` includes docs fileSet with:
+    - `<directory>${basedir}</directory>`
+    - `<include>docs/**</include>`
+    - `<outputDirectory>./</outputDirectory>`
+- If docs file is present but appears at ZIP root (`POLICY_STUDIO_DOC.md`), switch to `docs/**` include from `${basedir}` to preserve `docs/` path.
+- Check `docs/POLICY_STUDIO_DOC.md` exists before running `mvn package`.
+- Run `mvn clean package` to force rebuild.
+
+### Doc-Gen Config Path Issues
+
+**Symptom**: Docker container fails to find config or plugin files.
+
+**Fix**:
+- Use absolute paths: `DOCGEN_CONFIG_DIR="/full/path/to/gravitee-doc-gen-config/src"`.
+- Ensure config directory contains required doc-gen config files.
+- Check path doesn't contain spaces or special characters.
+- On Windows, use WSL2 paths or convert: `/c/Users/...` not `C:\Users\...`.
+
+### JSON Schema Type Validation Failures in Doc-Gen
+
+**Symptom**: Doc-gen fails with an error like `expected boolean, but got string` for `/src/main/resources/schemas/schema-form.json`.
+
+**Fix**:
+- Locate the referenced key (commonly `deprecated`).
+- Replace string values (`"true"` / `"false"`) with booleans (`true` / `false`).
+- Re-run doc-gen after the typing fix.
+
+### Maven Build Warnings About Missing README
+
+**Symptom**: Build warns about missing README in assembly.
+
+**Fix**:
+- This is expected if old `README.adoc` fileSet not removed from `policy-assembly.xml`.
+- Safe to ignore if new docs fileSet is correct.
+- Optionally clean up old fileSet reference.
+
+## Guardrails
+
+- Do not change Java code, runtime schema semantics, or policy identifiers.
+- Do not change CI unless explicitly requested.
+- Keep content concise and factual in `overview.md`.
+- Prefer examples derived from existing test fixtures over inventing new structures.

--- a/.docgen/examples.yaml
+++ b/.docgen/examples.yaml
@@ -1,0 +1,20 @@
+genExamples: []
+rawExamples:
+    - title: Add, update and remove query parameters
+      templateRef: v4-api-proxy
+      language: json
+      properties:
+          phase: request
+      file: .docgen/examples/add-update-remove.json
+    - title: Clear all and add a new query parameter
+      templateRef: v4-api-proxy
+      language: json
+      properties:
+          phase: request
+      file: .docgen/examples/clear-all.json
+    - title: Append values to an existing query parameter
+      templateRef: v4-api-proxy
+      language: json
+      properties:
+          phase: request
+      file: .docgen/examples/append.json

--- a/.docgen/examples/add-update-remove.json
+++ b/.docgen/examples/add-update-remove.json
@@ -1,0 +1,7 @@
+{
+    "addQueryParameters": [
+        { "name": "added", "value": "addedValue" },
+        { "name": "toUpdate", "value": "updatedValue" }
+    ],
+    "removeQueryParameters": ["toRemove"]
+}

--- a/.docgen/examples/append.json
+++ b/.docgen/examples/append.json
@@ -1,0 +1,6 @@
+{
+    "addQueryParameters": [
+        { "name": "appended", "value": "value1", "appendToExistingArray": true },
+        { "name": "appended", "value": "value2", "appendToExistingArray": true }
+    ]
+}

--- a/.docgen/examples/clear-all.json
+++ b/.docgen/examples/clear-all.json
@@ -1,0 +1,4 @@
+{
+    "clearAll": true,
+    "addQueryParameters": [{ "name": "added", "value": "addedValue" }]
+}

--- a/.docgen/matrix.yaml
+++ b/.docgen/matrix.yaml
@@ -1,0 +1,13 @@
+rows:
+    - data:
+          plugin: "2.x"
+          apim: "4.8.x to latest"
+          java: 21
+    - data:
+          plugin: "1.7.x"
+          apim: "4.0.x to 4.7.x"
+          java: 17
+    - data:
+          plugin: "1.6.x"
+          apim: "3.x"
+      deprecated: true

--- a/.docgen/overview.md
+++ b/.docgen/overview.md
@@ -1,0 +1,11 @@
+You can use the `{{ .Plugin.ID }}` policy to override incoming HTTP request query parameters.
+
+You can override HTTP query parameters by:
+
+* Clearing all existing query parameters
+* Adding to or updating the list of query parameters
+* Removing query parameters individually
+
+You can also append a value to an existing query parameter.
+
+Query parameter values of the incoming request are accessible via the `{#request.params['query_parameter_name']}` construct.

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,25 +1,4 @@
 {
-  "extends": ["config:base"],
-  "rebaseWhen": "conflicted",
-  "packageRules": [
-    {
-      "matchDatasources": ["orb"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true,
-      "automergeType": "branch",
-      "semanticCommitType": "ci"
-    },
-    {
-      "matchDepTypes": ["provided", "test", "build", "import", "parent"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true,
-      "automergeType": "branch",
-      "semanticCommitType": "chore"
-    },
-    {
-      "matchDepTypes": ["provided", "test", "build", "import", "parent"],
-      "matchUpdateTypes": ["major"],
-      "semanticCommitType": "chore"
-    }
-  ]
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["local>gravitee-io/renovate-config:plugin"]
 }

--- a/README.adoc
+++ b/README.adoc
@@ -38,7 +38,8 @@ The query parameter values of the incoming request are accessible via the `{#req
 |Plugin version | APIM version
 
 |Up to 1.6.x    | 3.x
-|1.7.x          | 4.0 to latest
+|1.7.x          | 4.0 to 4.7.x
+|2.x            | 4.8 to latest
 |===
 
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The `transform-queryparams` policy can be applied to the following API types and
 
 * `PROXY`
 * `MESSAGE`
+* `LLM PROXY`
 
 ### Supported flow phases:
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,215 @@
+
+<!-- GENERATED CODE - DO NOT ALTER THIS OR THE FOLLOWING LINES -->
+# Transform Query Parameters
+
+[![Gravitee.io](https://img.shields.io/static/v1?label=Available%20at&message=Gravitee.io&color=1EC9D2)](https://download.gravitee.io/#graviteeio-apim/plugins/policies/gravitee-policy-transform-queryparams/)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/gravitee-io/gravitee-policy-transform-queryparams/blob/master/LICENSE.txt)
+[![Releases](https://img.shields.io/badge/semantic--release-conventional%20commits-e10079?logo=semantic-release)](https://github.com/gravitee-io/gravitee-policy-transform-queryparams/releases)
+[![CircleCI](https://circleci.com/gh/gravitee-io/gravitee-policy-transform-queryparams.svg?style=svg)](https://circleci.com/gh/gravitee-io/gravitee-policy-transform-queryparams)
+
+## Overview
+You can use the `transform-queryparams` policy to override incoming HTTP request query parameters.
+
+You can override HTTP query parameters by:
+
+* Clearing all existing query parameters
+* Adding to or updating the list of query parameters
+* Removing query parameters individually
+
+You can also append a value to an existing query parameter.
+
+Query parameter values of the incoming request are accessible via the `{#request.params['query_parameter_name']}` construct.
+
+
+
+
+## Phases
+The `transform-queryparams` policy can be applied to the following API types and flow phases.
+
+### Compatible API types
+
+* `PROXY`
+* `MESSAGE`
+
+### Supported flow phases:
+
+* Request
+
+## Compatibility matrix
+Strikethrough text indicates that a version is deprecated.
+
+| Plugin version| APIM| Java version |
+| --- | --- | ---  |
+|2.x|4.8.x to latest|21 |
+|1.7.x|4.0.x to 4.7.x|17 |
+|~~1.6.x~~|~~3.x~~|~~-~~ |
+
+
+## Configuration options
+
+
+#### 
+| Name <br>`json name`  | Type <br>`constraint`  | Mandatory  | Default  | Description  |
+|:----------------------|:-----------------------|:----------:|:---------|:-------------|
+| Add or replace query parameter<br>`addQueryParameters`| array|  | | <br/>See "Add or replace query parameter" section.|
+| Clear all query parameters<br>`clearAll`| boolean|  | | Please be aware that by clearing all query parameters, you mustn't be able to use them in expression language.|
+| Remove query parameters<br>`removeQueryParameters`| array (string)|  | | |
+
+
+#### Add or replace query parameter (Array)
+| Name <br>`json name`  | Type <br>`constraint`  | Mandatory  | Default  | Description  |
+|:----------------------|:-----------------------|:----------:|:---------|:-------------|
+| Append the value to existing queryParam as an array (i.e. ?key=v1&key=v2&key=v3) ?<br>`appendToExistingArray`| boolean|  | | |
+| Name<br>`name`| string| ✅| | |
+| Value. (Supports EL)<br>`value`| string| ✅| | |
+
+
+
+
+## Examples
+
+*Add, update and remove query parameters*
+```json
+{
+  "api": {
+    "definitionVersion": "V4",
+    "type": "PROXY",
+    "name": "Transform Query Parameters example API",
+    "flows": [
+      {
+        "name": "Common Flow",
+        "enabled": true,
+        "selectors": [
+          {
+            "type": "HTTP",
+            "path": "/",
+            "pathOperator": "STARTS_WITH"
+          }
+        ],
+        "request": [
+          {
+            "name": "Transform Query Parameters",
+            "enabled": true,
+            "policy": "transform-queryparams",
+            "configuration":
+              {
+                  "addQueryParameters": [
+                      { "name": "added", "value": "addedValue" },
+                      { "name": "toUpdate", "value": "updatedValue" }
+                  ],
+                  "removeQueryParameters": ["toRemove"]
+              }
+          }
+        ]
+      }
+    ]
+  }
+}
+
+```
+*Clear all and add a new query parameter*
+```json
+{
+  "api": {
+    "definitionVersion": "V4",
+    "type": "PROXY",
+    "name": "Transform Query Parameters example API",
+    "flows": [
+      {
+        "name": "Common Flow",
+        "enabled": true,
+        "selectors": [
+          {
+            "type": "HTTP",
+            "path": "/",
+            "pathOperator": "STARTS_WITH"
+          }
+        ],
+        "request": [
+          {
+            "name": "Transform Query Parameters",
+            "enabled": true,
+            "policy": "transform-queryparams",
+            "configuration":
+              {
+                  "clearAll": true,
+                  "addQueryParameters": [{ "name": "added", "value": "addedValue" }]
+              }
+          }
+        ]
+      }
+    ]
+  }
+}
+
+```
+*Append values to an existing query parameter*
+```json
+{
+  "api": {
+    "definitionVersion": "V4",
+    "type": "PROXY",
+    "name": "Transform Query Parameters example API",
+    "flows": [
+      {
+        "name": "Common Flow",
+        "enabled": true,
+        "selectors": [
+          {
+            "type": "HTTP",
+            "path": "/",
+            "pathOperator": "STARTS_WITH"
+          }
+        ],
+        "request": [
+          {
+            "name": "Transform Query Parameters",
+            "enabled": true,
+            "policy": "transform-queryparams",
+            "configuration":
+              {
+                  "addQueryParameters": [
+                      { "name": "appended", "value": "value1", "appendToExistingArray": true },
+                      { "name": "appended", "value": "value2", "appendToExistingArray": true }
+                  ]
+              }
+          }
+        ]
+      }
+    ]
+  }
+}
+
+```
+
+
+## Changelog
+
+### [1.9.0](https://github.com/gravitee-io/gravitee-policy-transformqueryparams/compare/1.8.0...1.9.0) (2023-12-19)
+
+
+##### Features
+
+* enable policy on REQUEST phase for message APIs ([5d080cd](https://github.com/gravitee-io/gravitee-policy-transformqueryparams/commit/5d080cd570df79b3373f10d017c485886718f219)), closes [gravitee-io/issues#9430](https://github.com/gravitee-io/issues/issues/9430)
+
+### [1.8.0](https://github.com/gravitee-io/gravitee-policy-transformqueryparams/compare/1.7.1...1.8.0) (2023-12-01)
+
+
+##### Features
+
+* add an option to handle array of values in a query parameter ([253127b](https://github.com/gravitee-io/gravitee-policy-transformqueryparams/commit/253127bc1a071413ac124a11237707972f9ed557))
+
+#### [1.7.1](https://github.com/gravitee-io/gravitee-policy-transformqueryparams/compare/1.7.0...1.7.1) (2023-07-20)
+
+
+##### Bug Fixes
+
+* update policy description ([91bc7bd](https://github.com/gravitee-io/gravitee-policy-transformqueryparams/commit/91bc7bd375a9a53bd13c11591717e0a2be694cce))
+
+### [1.7.0](https://github.com/gravitee-io/gravitee-policy-transformqueryparams/compare/1.6.0...1.7.0) (2023-07-05)
+
+
+##### Features
+
+* addition of the execution phase ([9061fa3](https://github.com/gravitee-io/gravitee-policy-transformqueryparams/commit/9061fa36f18948a03fa57abce95b509576703264))
+

--- a/docs/POLICY_STUDIO_DOC.md
+++ b/docs/POLICY_STUDIO_DOC.md
@@ -1,0 +1,15 @@
+## Overview
+You can use the `transform-queryparams` policy to override incoming HTTP request query parameters.
+
+You can override HTTP query parameters by:
+
+* Clearing all existing query parameters
+* Adding to or updating the list of query parameters
+* Removing query parameters individually
+
+You can also append a value to an existing query parameter.
+
+Query parameter values of the incoming request are accessible via the `{#request.params['query_parameter_name']}` construct.
+
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>21.0.1</version>
+        <version>23.5.0</version>
     </parent>
 
     <properties>
@@ -38,10 +38,8 @@
         <gravitee-policy-api.version>1.10.0</gravitee-policy-api.version>
         <gravitee-common.version>1.19.0</gravitee-common.version>
         <gravitee-bom.version>5.0.0</gravitee-bom.version>
-        <json-schema-generator-maven-plugin.version>1.1.0</json-schema-generator-maven-plugin.version>
-        <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
 
-        <maven-assembly-plugin.version>2.6</maven-assembly-plugin.version>
+        <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
     </properties>
@@ -124,7 +122,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>properties-maven-plugin</artifactId>
-                <version>1.2.1</version>
+                <version>${properties-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <phase>initialize</phase>
@@ -143,7 +141,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>${maven-assembly-plugin.version}</version>
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <descriptors>
@@ -160,24 +157,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>com.hubspot.maven.plugins</groupId>
-                <artifactId>prettier-maven-plugin</artifactId>
-                <version>0.22</version>
-                <configuration>
-                    <nodeVersion>12.13.0</nodeVersion>
-                    <prettierJavaVersion>1.6.1</prettierJavaVersion>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
@@ -34,10 +34,8 @@
     </parent>
 
     <properties>
-        <gravitee-gateway-api.version>1.23.0</gravitee-gateway-api.version>
-        <gravitee-policy-api.version>1.10.0</gravitee-policy-api.version>
-        <gravitee-common.version>1.19.0</gravitee-common.version>
-        <gravitee-bom.version>5.0.0</gravitee-bom.version>
+        <gravitee-apim.version>4.8.0</gravitee-apim.version>
+        <lombok.version>1.18.34</lombok.version>
 
         <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
         <!-- Property used by the publication job in CI-->
@@ -48,9 +46,9 @@
         <dependencies>
             <!-- Import bom to properly inherit all dependencies -->
             <dependency>
-                <groupId>io.gravitee</groupId>
-                <artifactId>gravitee-bom</artifactId>
-                <version>${gravitee-bom.version}</version>
+                <groupId>io.gravitee.apim</groupId>
+                <artifactId>gravitee-apim-bom</artifactId>
+                <version>${gravitee-apim.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -62,21 +60,18 @@
         <dependency>
             <groupId>io.gravitee.gateway</groupId>
             <artifactId>gravitee-gateway-api</artifactId>
-            <version>${gravitee-gateway-api.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.policy</groupId>
             <artifactId>gravitee-policy-api</artifactId>
-            <version>${gravitee-policy-api.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.common</groupId>
             <artifactId>gravitee-common</artifactId>
-            <version>${gravitee-common.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -94,6 +89,25 @@
 
         <!-- Test scope -->
         <dependency>
+            <groupId>io.gravitee.apim.gateway</groupId>
+            <artifactId>gravitee-apim-gateway-tests-sdk</artifactId>
+            <version>${gravitee-apim.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.apim.plugin.entrypoint</groupId>
+            <artifactId>gravitee-apim-plugin-entrypoint-http-proxy</artifactId>
+            <version>${gravitee-apim.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.apim.plugin.endpoint</groupId>
+            <artifactId>gravitee-apim-plugin-endpoint-http-proxy</artifactId>
+            <version>${gravitee-apim.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
@@ -107,6 +121,12 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/assembly/policy-assembly.xml
+++ b/src/assembly/policy-assembly.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/assembly/policy-assembly.xml
+++ b/src/assembly/policy-assembly.xml
@@ -41,9 +41,9 @@
         <fileSet>
             <directory>${basedir}</directory>
             <includes>
-                <include>README.adoc</include>
+                <include>docs/**</include>
             </includes>
-            <outputDirectory>docs</outputDirectory>
+            <outputDirectory>./</outputDirectory>
         </fileSet>
 
         <fileSet>

--- a/src/main/java/io/gravitee/policy/transformqueryparams/TransformQueryParametersPolicy.java
+++ b/src/main/java/io/gravitee/policy/transformqueryparams/TransformQueryParametersPolicy.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/transformqueryparams/configuration/HttpQueryParameter.java
+++ b/src/main/java/io/gravitee/policy/transformqueryparams/configuration/HttpQueryParameter.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/transformqueryparams/configuration/TransformQueryParametersPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/transformqueryparams/configuration/TransformQueryParametersPolicyConfiguration.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -8,3 +8,4 @@ category=transformation
 icon=transform-query-params.svg
 proxy=REQUEST
 message=REQUEST
+llm_proxy=REQUEST

--- a/src/test/java/io/gravitee/policy/transformqueryparams/TransformQueryParametersPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/transformqueryparams/TransformQueryParametersPolicyTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/transformqueryparams/TransformQueryParametersPolicyV4IntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/transformqueryparams/TransformQueryParametersPolicyV4IntegrationTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.transformqueryparams;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.havingExactly;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractPolicyTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.policy.transformqueryparams.configuration.TransformQueryParametersPolicyConfiguration;
+import io.reactivex.rxjava3.observers.TestObserver;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import io.vertx.rxjava3.core.http.HttpClientResponse;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@GatewayTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class TransformQueryParametersPolicyV4IntegrationTest
+    extends AbstractPolicyTest<TransformQueryParametersPolicy, TransformQueryParametersPolicyConfiguration> {
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+    }
+
+    @Test
+    @DeployApi("/apis/v4/clear-queryparams.json")
+    void should_clear_all_query_parameters_with_proxy_api(HttpClient client) throws InterruptedException {
+        wiremock.stubFor(get(urlPathEqualTo("/endpoint")).willReturn(ok()));
+
+        final TestObserver<HttpClientResponse> obs = client
+            .rxRequest(HttpMethod.GET, "/test?keep=value&drop=value")
+            .flatMap(HttpClientRequest::rxSend)
+            .test();
+
+        awaitTerminalEvent(obs);
+        obs
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(
+            getRequestedFor(urlPathEqualTo("/endpoint"))
+                .withQueryParam("added", equalTo("addedValue"))
+                .withoutQueryParam("keep")
+                .withoutQueryParam("drop")
+        );
+    }
+
+    @Test
+    @DeployApi("/apis/v4/add-update-remove-queryparams.json")
+    void should_add_update_and_remove_query_parameters_with_proxy_api(HttpClient client) throws InterruptedException {
+        wiremock.stubFor(get(urlPathEqualTo("/endpoint")).willReturn(ok()));
+
+        final TestObserver<HttpClientResponse> obs = client
+            .rxRequest(HttpMethod.GET, "/test?toUpdate=originalValue&toRemove=byebye&untouched=stay")
+            .flatMap(HttpClientRequest::rxSend)
+            .test();
+
+        awaitTerminalEvent(obs);
+        obs
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(
+            getRequestedFor(urlPathEqualTo("/endpoint"))
+                .withQueryParam("added", equalTo("addedValue"))
+                .withQueryParam("toUpdate", equalTo("updatedValue"))
+                .withQueryParam("untouched", equalTo("stay"))
+                .withoutQueryParam("toRemove")
+        );
+    }
+
+    @Test
+    @DeployApi("/apis/v4/append-queryparams.json")
+    void should_append_query_parameter_with_proxy_api(HttpClient client) throws InterruptedException {
+        wiremock.stubFor(get(urlPathEqualTo("/endpoint")).willReturn(ok()));
+
+        final TestObserver<HttpClientResponse> obs = client
+            .rxRequest(HttpMethod.GET, "/test?appended=value0")
+            .flatMap(HttpClientRequest::rxSend)
+            .test();
+
+        awaitTerminalEvent(obs);
+        obs
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(
+            getRequestedFor(urlPathEqualTo("/endpoint")).withQueryParam(
+                "appended",
+                havingExactly(equalTo("value0"), equalTo("value1"), equalTo("value2"))
+            )
+        );
+    }
+}

--- a/src/test/java/io/gravitee/policy/transformqueryparams/v3/TransformQueryParametersPolicyV3IntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/transformqueryparams/v3/TransformQueryParametersPolicyV3IntegrationTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.transformqueryparams.v3;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.havingExactly;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractPolicyTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.definition.model.ExecutionMode;
+import io.gravitee.policy.transformqueryparams.TransformQueryParametersPolicy;
+import io.gravitee.policy.transformqueryparams.configuration.TransformQueryParametersPolicyConfiguration;
+import io.reactivex.rxjava3.observers.TestObserver;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import io.vertx.rxjava3.core.http.HttpClientResponse;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@GatewayTest(v2ExecutionMode = ExecutionMode.V3)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class TransformQueryParametersPolicyV3IntegrationTest
+    extends AbstractPolicyTest<TransformQueryParametersPolicy, TransformQueryParametersPolicyConfiguration> {
+
+    @Test
+    @DeployApi("/apis/v2/clear-queryparams.json")
+    void should_clear_all_query_parameters(HttpClient client) throws InterruptedException {
+        wiremock.stubFor(get(urlPathEqualTo("/endpoint")).willReturn(ok()));
+
+        final TestObserver<HttpClientResponse> obs = client
+            .rxRequest(HttpMethod.GET, "/test?keep=value&drop=value")
+            .flatMap(HttpClientRequest::rxSend)
+            .test();
+
+        awaitTerminalEvent(obs);
+        obs
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(
+            getRequestedFor(urlPathEqualTo("/endpoint"))
+                .withQueryParam("added", equalTo("addedValue"))
+                .withoutQueryParam("keep")
+                .withoutQueryParam("drop")
+        );
+    }
+
+    @Test
+    @DeployApi("/apis/v2/add-update-remove-queryparams.json")
+    void should_add_update_and_remove_query_parameters(HttpClient client) throws InterruptedException {
+        wiremock.stubFor(get(urlPathEqualTo("/endpoint")).willReturn(ok()));
+
+        final TestObserver<HttpClientResponse> obs = client
+            .rxRequest(HttpMethod.GET, "/test?toUpdate=originalValue&toRemove=byebye&untouched=stay")
+            .flatMap(HttpClientRequest::rxSend)
+            .test();
+
+        awaitTerminalEvent(obs);
+        obs
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(
+            getRequestedFor(urlPathEqualTo("/endpoint"))
+                .withQueryParam("added", equalTo("addedValue"))
+                .withQueryParam("toUpdate", equalTo("updatedValue"))
+                .withQueryParam("untouched", equalTo("stay"))
+                .withoutQueryParam("toRemove")
+        );
+    }
+
+    @Test
+    @DeployApi("/apis/v2/append-queryparams.json")
+    void should_append_query_parameter(HttpClient client) throws InterruptedException {
+        wiremock.stubFor(get(urlPathEqualTo("/endpoint")).willReturn(ok()));
+
+        final TestObserver<HttpClientResponse> obs = client
+            .rxRequest(HttpMethod.GET, "/test?appended=value0")
+            .flatMap(HttpClientRequest::rxSend)
+            .test();
+
+        awaitTerminalEvent(obs);
+        obs
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(
+            getRequestedFor(urlPathEqualTo("/endpoint")).withQueryParam(
+                "appended",
+                havingExactly(equalTo("value0"), equalTo("value1"), equalTo("value2"))
+            )
+        );
+    }
+}

--- a/src/test/java/io/gravitee/policy/transformqueryparams/v3/TransformQueryParametersPolicyV4EmulationIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/transformqueryparams/v3/TransformQueryParametersPolicyV4EmulationIntegrationTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.transformqueryparams.v3;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.definition.model.ExecutionMode;
+
+@GatewayTest(v2ExecutionMode = ExecutionMode.V4_EMULATION_ENGINE)
+class TransformQueryParametersPolicyV4EmulationIntegrationTest extends TransformQueryParametersPolicyV3IntegrationTest {}

--- a/src/test/resources/apis/v2/add-update-remove-queryparams.json
+++ b/src/test/resources/apis/v2/add-update-remove-queryparams.json
@@ -1,0 +1,50 @@
+{
+    "id": "my-api",
+    "name": "my-api",
+    "gravitee": "2.0.0",
+    "proxy": {
+        "context_path": "/test",
+        "endpoints": [
+            {
+                "name": "default",
+                "target": "http://localhost:8080/endpoint",
+                "http": {
+                    "connectTimeout": 3000,
+                    "readTimeout": 60000
+                }
+            }
+        ]
+    },
+    "flows": [
+        {
+            "name": "flow-1",
+            "methods": ["GET"],
+            "enabled": true,
+            "path-operator": {
+                "path": "/",
+                "operator": "STARTS_WITH"
+            },
+            "pre": [
+                {
+                    "name": "Transform Query Parameters",
+                    "description": "Add, update and remove query parameters",
+                    "enabled": true,
+                    "policy": "transform-queryparams",
+                    "configuration": {
+                        "addQueryParameters": [
+                            {
+                                "name": "added",
+                                "value": "addedValue"
+                            },
+                            {
+                                "name": "toUpdate",
+                                "value": "updatedValue"
+                            }
+                        ],
+                        "removeQueryParameters": ["toRemove"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/src/test/resources/apis/v2/append-queryparams.json
+++ b/src/test/resources/apis/v2/append-queryparams.json
@@ -1,0 +1,51 @@
+{
+    "id": "my-api",
+    "name": "my-api",
+    "gravitee": "2.0.0",
+    "proxy": {
+        "context_path": "/test",
+        "endpoints": [
+            {
+                "name": "default",
+                "target": "http://localhost:8080/endpoint",
+                "http": {
+                    "connectTimeout": 3000,
+                    "readTimeout": 60000
+                }
+            }
+        ]
+    },
+    "flows": [
+        {
+            "name": "flow-1",
+            "methods": ["GET"],
+            "enabled": true,
+            "path-operator": {
+                "path": "/",
+                "operator": "STARTS_WITH"
+            },
+            "pre": [
+                {
+                    "name": "Transform Query Parameters",
+                    "description": "Append values to an existing query parameter",
+                    "enabled": true,
+                    "policy": "transform-queryparams",
+                    "configuration": {
+                        "addQueryParameters": [
+                            {
+                                "name": "appended",
+                                "value": "value1",
+                                "appendToExistingArray": true
+                            },
+                            {
+                                "name": "appended",
+                                "value": "value2",
+                                "appendToExistingArray": true
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/src/test/resources/apis/v2/clear-queryparams.json
+++ b/src/test/resources/apis/v2/clear-queryparams.json
@@ -1,0 +1,46 @@
+{
+    "id": "my-api",
+    "name": "my-api",
+    "gravitee": "2.0.0",
+    "proxy": {
+        "context_path": "/test",
+        "endpoints": [
+            {
+                "name": "default",
+                "target": "http://localhost:8080/endpoint",
+                "http": {
+                    "connectTimeout": 3000,
+                    "readTimeout": 60000
+                }
+            }
+        ]
+    },
+    "flows": [
+        {
+            "name": "flow-1",
+            "methods": ["GET"],
+            "enabled": true,
+            "path-operator": {
+                "path": "/",
+                "operator": "STARTS_WITH"
+            },
+            "pre": [
+                {
+                    "name": "Transform Query Parameters",
+                    "description": "Clear all query parameters and add a new one",
+                    "enabled": true,
+                    "policy": "transform-queryparams",
+                    "configuration": {
+                        "clearAll": true,
+                        "addQueryParameters": [
+                            {
+                                "name": "added",
+                                "value": "addedValue"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/src/test/resources/apis/v4/add-update-remove-queryparams.json
+++ b/src/test/resources/apis/v4/add-update-remove-queryparams.json
@@ -1,0 +1,66 @@
+{
+    "id": "my-api",
+    "name": "my-api",
+    "apiVersion": "1.0",
+    "definitionVersion": "4.0.0",
+    "type": "proxy",
+    "listeners": [
+        {
+            "type": "http",
+            "paths": [
+                {
+                    "path": "/test"
+                }
+            ],
+            "entrypoints": [
+                {
+                    "type": "http-proxy"
+                }
+            ]
+        }
+    ],
+    "endpointGroups": [
+        {
+            "name": "default-group",
+            "type": "http-proxy",
+            "endpoints": [
+                {
+                    "name": "default",
+                    "type": "http-proxy",
+                    "weight": 1,
+                    "inheritConfiguration": false,
+                    "configuration": {
+                        "target": "http://localhost:8080/endpoint"
+                    }
+                }
+            ]
+        }
+    ],
+    "flows": [
+        {
+            "name": "flow-1",
+            "enabled": true,
+            "request": [
+                {
+                    "name": "Transform Query Parameters",
+                    "description": "Add, update and remove query parameters",
+                    "enabled": true,
+                    "policy": "transform-queryparams",
+                    "configuration": {
+                        "addQueryParameters": [
+                            {
+                                "name": "added",
+                                "value": "addedValue"
+                            },
+                            {
+                                "name": "toUpdate",
+                                "value": "updatedValue"
+                            }
+                        ],
+                        "removeQueryParameters": ["toRemove"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/src/test/resources/apis/v4/append-queryparams.json
+++ b/src/test/resources/apis/v4/append-queryparams.json
@@ -1,0 +1,67 @@
+{
+    "id": "my-api",
+    "name": "my-api",
+    "apiVersion": "1.0",
+    "definitionVersion": "4.0.0",
+    "type": "proxy",
+    "listeners": [
+        {
+            "type": "http",
+            "paths": [
+                {
+                    "path": "/test"
+                }
+            ],
+            "entrypoints": [
+                {
+                    "type": "http-proxy"
+                }
+            ]
+        }
+    ],
+    "endpointGroups": [
+        {
+            "name": "default-group",
+            "type": "http-proxy",
+            "endpoints": [
+                {
+                    "name": "default",
+                    "type": "http-proxy",
+                    "weight": 1,
+                    "inheritConfiguration": false,
+                    "configuration": {
+                        "target": "http://localhost:8080/endpoint"
+                    }
+                }
+            ]
+        }
+    ],
+    "flows": [
+        {
+            "name": "flow-1",
+            "enabled": true,
+            "request": [
+                {
+                    "name": "Transform Query Parameters",
+                    "description": "Append values to an existing query parameter",
+                    "enabled": true,
+                    "policy": "transform-queryparams",
+                    "configuration": {
+                        "addQueryParameters": [
+                            {
+                                "name": "appended",
+                                "value": "value1",
+                                "appendToExistingArray": true
+                            },
+                            {
+                                "name": "appended",
+                                "value": "value2",
+                                "appendToExistingArray": true
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/src/test/resources/apis/v4/clear-queryparams.json
+++ b/src/test/resources/apis/v4/clear-queryparams.json
@@ -1,0 +1,62 @@
+{
+    "id": "my-api",
+    "name": "my-api",
+    "apiVersion": "1.0",
+    "definitionVersion": "4.0.0",
+    "type": "proxy",
+    "listeners": [
+        {
+            "type": "http",
+            "paths": [
+                {
+                    "path": "/test"
+                }
+            ],
+            "entrypoints": [
+                {
+                    "type": "http-proxy"
+                }
+            ]
+        }
+    ],
+    "endpointGroups": [
+        {
+            "name": "default-group",
+            "type": "http-proxy",
+            "endpoints": [
+                {
+                    "name": "default",
+                    "type": "http-proxy",
+                    "weight": 1,
+                    "inheritConfiguration": false,
+                    "configuration": {
+                        "target": "http://localhost:8080/endpoint"
+                    }
+                }
+            ]
+        }
+    ],
+    "flows": [
+        {
+            "name": "flow-1",
+            "enabled": true,
+            "request": [
+                {
+                    "name": "Transform Query Parameters",
+                    "description": "Clear all query parameters and add a new one",
+                    "enabled": true,
+                    "policy": "transform-queryparams",
+                    "configuration": {
+                        "clearAll": true,
+                        "addQueryParameters": [
+                            {
+                                "name": "added",
+                                "value": "addedValue"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
**Description**

Enable this policy for LLM_PROXY APIs

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-claude-thirsty-albattani-308153-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-transformqueryparams/2.0.0-claude-thirsty-albattani-308153-SNAPSHOT/gravitee-policy-transformqueryparams-2.0.0-claude-thirsty-albattani-308153-SNAPSHOT.zip)
  <!-- Version placeholder end -->
